### PR TITLE
Remove trailing comma of 'Key Bindings' @ README

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ In your keymap file (Preferences >> Key bindings - User), add a custom key bindi
 [
     {
         "keys": ["alt+w"],
-        "command": "sass_beautify",
+        "command": "sass_beautify"
     }
 ]
 ```


### PR DESCRIPTION
Fix following error in Sublime Text 2 after copy/pasting the suggested key binding in the README file:

![trailing_comma_sassbeautify](https://cloud.githubusercontent.com/assets/1498567/6234122/7b383dd0-b6d8-11e4-9575-f08689d59ba9.png)
