### PR TITLE
Add option to trim leading zero from numeric values with a decimal point

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ The following settings can be adjusted:
   "newlineBetweenSelectors": false,
   // Use single quotes everywhere
   "useSingleQuotes": false
+  // Remove the leading zero for numeric values with a decimal point
+  "leadingZero": false
 }
 ```
 
@@ -102,7 +104,7 @@ In your keymap file (Preferences >> Key bindings - User), add a custom key bindi
 
 ## Issues with ruby, Sass and your PATH
 
-If you installed ruby and sass via a version manager tool like [RVM](https://rvm.io/), [rbenv](https://github.com/sstephenson/rbenv) or via an installer like [ruby installer](http://rubyinstaller.org/), then you're likely to encounter issues with running `sass-convert` from Sublime Text. 
+If you installed ruby and sass via a version manager tool like [RVM](https://rvm.io/), [rbenv](https://github.com/sstephenson/rbenv) or via an installer like [ruby installer](http://rubyinstaller.org/), then you're likely to encounter issues with running `sass-convert` from Sublime Text.
 
 ### Compatibility with RVM/rbenv
 
@@ -128,7 +130,7 @@ Please [create an issue](https://github.com/badsyntax/SassBeautify/issues) if yo
 
 ## Thanks
 
-Thanks to the [contributors](https://github.com/badsyntax/SassBeautify/graphs/contributors) and to all the people 
+Thanks to the [contributors](https://github.com/badsyntax/SassBeautify/graphs/contributors) and to all the people
 who have tested and reported issues.
 
 ## License

--- a/SassBeautify.py
+++ b/SassBeautify.py
@@ -173,10 +173,13 @@ class SassBeautifyCommand(sublime_plugin.TextCommand):
         content = re.sub(re.compile('(;.*|}.*)(\n +//.*\n.+[{,])$', re.MULTILINE), insert_newline_between_capturing_parentheses, content)
 
         return content
-        
+
     def use_single_quotes(self, content):
         content = content.replace('"', '\'')
         return content
+
+    def remove_leading_zero(self, content):
+        return re.sub(r'([\( ]+)0\.(\d*)', r'\1.\2', content)
 
     def check_thread(self, thread, i=0, dir=1):
         '''
@@ -229,9 +232,12 @@ class SassBeautifyCommand(sublime_plugin.TextCommand):
 
         if self.settings.get('newlineBetweenSelectors', False):
             output = self.beautify_newlines(output)
-        
+
         if self.settings.get('useSingleQuotes', False):
             output = self.use_single_quotes(output)
+
+        if self.settings.get('leadingZero', False):
+            output = self.remove_leading_zero(output)
 
         self.viewport_pos = self.view.viewport_position()
         self.selection = self.view.sel()[0]

--- a/SassBeautify.sublime-settings
+++ b/SassBeautify.sublime-settings
@@ -5,5 +5,6 @@
 	"path": false,
 	"beautifyOnSave": false,
 	"inlineComments": false,
-	"newlineBetweenSelectors": false
+	"newlineBetweenSelectors": false,
+	"leadingZero": false
 }

--- a/tests/test.py
+++ b/tests/test.py
@@ -211,3 +211,27 @@ class test_internal_function_beautify_newlines(TestCase):
             }
 
             """))
+
+class test_internal_function_remove_leading_zero(TestCase):
+
+    # check that leading zeros are removed properly
+    def test_leading_zero(self):
+        beautified = SassBeautifyCommandInstance.remove_leading_zero(textwrap.dedent("""\
+
+            .ClassA {
+                -webkit-transform: scale(0.9);
+                transition: -webkit-transform 0.1s;
+                background-color: rgba(67, 67, 67, 0.5);
+            }
+
+            """))
+
+        self.assertEqual(beautified, textwrap.dedent("""\
+
+            .ClassA {
+                -webkit-transform: scale(.9);
+                transition: -webkit-transform .1s;
+                background-color: rgba(67, 67, 67, .5);
+            }
+
+            """))


### PR DESCRIPTION
Here's a solution for Issue #110.  I don't know if you want to head down this direction of adding options for scss-lint settings.  I know there are other scss-lint settings I'd like to bring over to SassBeautify, and doing each one at a time could complicate things rather quickly.

I also added a unit test, but I'm having trouble running the unit tests so I'm not 100% sure it will pass (although it looks like it should)

I should also mention I left the current behavior as the default.
