### PR TITLE
Add semicolons where they are missing so sass-convert does not error out

### DIFF
--- a/SassBeautify.py
+++ b/SassBeautify.py
@@ -173,9 +173,22 @@ class SassBeautifyCommand(sublime_plugin.TextCommand):
         content = re.sub(re.compile('(;.*|}.*)(\n +//.*\n.+[{,])$', re.MULTILINE), insert_newline_between_capturing_parentheses, content)
 
         return content
-        
+
     def use_single_quotes(self, content):
         content = content.replace('"', '\'')
+        return content
+
+    def beautify_semicolons(self, content):
+        '''
+        Appends a semicolon to the lines missing one
+        '''
+        def remove_semicolon_from_end_of_comment(m):
+            return m.group(1) + m.group(2)
+
+        content = re.sub(re.compile('(?<!,)$', re.MULTILINE), ';', content) # add ; to all lines not ending in ,
+        content = re.sub(re.compile(';(?=$\s*\{)', re.MULTILINE), '', content) # remove ; if next line starts with {
+        content = re.sub(re.compile('(//|/\\*)(.*);$', re.MULTILINE), remove_semicolon_from_end_of_comment, content) # remove ; if at end of comment
+        # sass-convert removes all other cases of extra ;s, so don't worry about them here
         return content
 
     def check_thread(self, thread, i=0, dir=1):
@@ -229,7 +242,7 @@ class SassBeautifyCommand(sublime_plugin.TextCommand):
 
         if self.settings.get('newlineBetweenSelectors', False):
             output = self.beautify_newlines(output)
-        
+
         if self.settings.get('useSingleQuotes', False):
             output = self.use_single_quotes(output)
 
@@ -309,6 +322,8 @@ class SassBeautifyCommand(sublime_plugin.TextCommand):
         Gets the sass text from the Sublime view.
         '''
         content = self.view.substr(sublime.Region(0, self.view.size()))
+
+        content = self.beautify_semicolons(content)
 
         if self.settings.get('inlineComments', False):
             '''

--- a/tests/test.py
+++ b/tests/test.py
@@ -237,7 +237,7 @@ class test_internal_function_beautify_semicolons(TestCase):
             """))
 
         self.assertEqual(beautified, textwrap.dedent("""\
-
+            ;
             // @import '_common';
             @import "_colors";
             ;
@@ -251,5 +251,5 @@ class test_internal_function_beautify_semicolons(TestCase):
                 font-size: 2em;;
                 margin: -3px 0 !important;
             };
-
-            """))
+            ;
+            ;"""))

--- a/tests/test.py
+++ b/tests/test.py
@@ -211,3 +211,45 @@ class test_internal_function_beautify_newlines(TestCase):
             }
 
             """))
+
+class test_internal_function_beautify_semicolons(TestCase):
+
+    # Check that we add ;s to the end of lines, except for comments, lines ending in commas, and lines before an open {
+    # all other cases where we might introduce a double semicolon or where a semicolon isn't needed are cleaned up by
+    # sass-convert so we don't need to worry about them here
+    def test_semicolons(self):
+        beautified = SassBeautifyCommandInstance.beautify_semicolons(textwrap.dedent("""\
+
+            // @import '_common';
+            @import "_colors"
+
+            //TODO: eat pizza
+            //      and other things
+
+            .ClassA,
+            .ClassB
+            {
+                height: 14px
+                font-size: 2em;
+                margin: -3px 0 !important
+            }
+
+            """))
+
+        self.assertEqual(beautified, textwrap.dedent("""\
+
+            // @import '_common';
+            @import "_colors";
+            ;
+            //TODO: eat pizza
+            //      and other things
+            ;
+            .ClassA,
+            .ClassB
+            {;
+                height: 14px;
+                font-size: 2em;;
+                margin: -3px 0 !important;
+            };
+
+            """))


### PR DESCRIPTION
Here's a potential solution for issue #115.  My regex-fu is a bit weak, so there might be a better way of doing this.
